### PR TITLE
GATE-483 : Added watchdog to install.sh

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -153,7 +153,7 @@ enable_watchdog_service()
     is_watchdog_service_enabled
     watchdog_service_state=$?
     if [ $watchdog_service_state == 0 ]; then
-        echo "Starting watchdog service"
+        #echo "Starting watchdog service"
         systemctl enable watchdog
         systemctl start watchdog
         systemctl status --no-pager watchdog
@@ -170,7 +170,7 @@ disable_watchdog_service()
     is_watchdog_service_enabled
     watchdog_service_state=$?
     if [ $watchdog_service_state == 1 ]; then
-        echo "Stopping watchdog service"
+        #echo "Stopping watchdog service"
         systemctl disable watchdog
         systemctl stop watchdog
         systemctl status --no-pager watchdog
@@ -190,21 +190,19 @@ watchdog_init ()
         is_watchdog_installed
         installed_status=$?
         if [ $installed_status == 1 ]; then
-            echo "Watchdog installed and ready"
+            #echo "Watchdog installed and ready"
             is_watchdog_configured
             config_status=$?
             if [ $config_status == 0 ]; then
-                echo "Watchdog config being added"
+                #echo "Watchdog config being added"
                 add_watchdog_config
                 is_watchdog_configured
                 config_status=$?
-                if [ $config_status == 1 ]; then
-                    echo "Watchdog Config success"
-                else
+                if [ $config_status == 0 ]; then
                     echo "Error: Watchdog Config Add Failed"
                 fi           
             else
-                echo "Watchdog config being updated"
+                #echo "Watchdog config being updated"
                 update_watchdog_config
             fi
 
@@ -214,21 +212,19 @@ watchdog_init ()
             is_watchdog_installed
             installed_status=$?
             if [ $installed_status == 1 ]; then
-                echo "Watchdog installed and ready"
+                #echo "Watchdog installed and ready"
                 is_watchdog_configured
                 config_status=$?
                 if [ $config_status == 0 ]; then
-                    echo "Watchdog config being added"
+                    #echo "Watchdog config being added"
                     add_watchdog_config
                     is_watchdog_configured
                     config_status=$?
-                    if [ $config_status == 1 ]; then
-                        echo "Watchdog Config success"
-                    else
+                    if [ $config_status == 0 ]; then
                         echo "Error: Watchdog Config Add Failed"
                     fi              
                 else
-                    echo "Watchdog config being updated"
+                    #echo "Watchdog config being updated"
                     update_watchdog_config
                 fi
             else
@@ -467,6 +463,9 @@ do_install ()
             Info "Not reinstalling service [$service]."
             do_exit 1
         fi
+
+        #disable watchdog
+        disable_watchdog_service
 
         # if interested uninstall first
         do_uninstall

--- a/install.sh
+++ b/install.sh
@@ -72,6 +72,181 @@ log_docker_info ()
     fi
 }
 
+######### watchdog
+is_watchdog_in_boot_config ()
+{
+    cmd="grep dtparam=watchdog=on /boot/config.txt -c"
+    watchdog_enabled=$($cmd)
+    if [ $watchdog_enabled == 0 ]; then
+        return 0
+    fi
+    return 1  
+}
+
+add_watchdog_to_boot_config ()
+{
+    echo 'dtparam=watchdog=on' >> /boot/config.txt
+}
+
+is_watchdog_dev_present ()
+{
+    CHAR_FILE=/dev/watchdog
+
+    if test -c $CHAR_FILE; then
+        return 1  
+    fi
+    return 0
+}
+
+is_watchdog_installed ()
+{
+    if [ -x "$(command -v watchdog)" ]; then
+        return 1  
+    fi
+    return 0
+}
+
+install_watchdog ()
+{
+    #apt update
+    apt install watchdog
+}
+
+is_watchdog_configured ()
+{
+    cmd="grep PowerFly /etc/watchdog.conf -c"
+    watchdog_configured=$($cmd)
+    if [ $watchdog_configured == 0 ]; then
+        return 0
+    fi
+    return 1  
+}
+
+update_watchdog_config ()
+{
+    powerfly_log=$('pwd')/logging.txt
+    sed -i 's@file = [a-zA-Z0-9_-]*@file = '$powerfly_log'@g' /etc/watchdog.conf
+}
+
+add_watchdog_config ()
+{
+    echo '#Watchdog Config for PowerFly' >> /etc/watchdog.conf
+    update_watchdog_config
+    echo 'watchdog-timeout = 60' >> /etc/watchdog.conf
+    echo 'max-load-1 = 24' >> /etc/watchdog.conf
+    echo 'file = '$powerfly_log  >> /etc/watchdog.conf
+    echo 'change = 60'  >> /etc/watchdog.conf
+}
+
+is_watchdog_service_enabled()
+{
+    cmd='systemctl is-active watchdog'
+    service_state=$($cmd)
+    if [ $service_state == "active" ]; then
+        return 1 ;
+    fi
+    return 0
+}
+
+enable_watchdog_service()
+{
+    systemctl enable watchdog
+    systemctl start watchdog
+    systemctl status watchdog
+    is_watchdog_service_enabled
+    watchdog_service_state=$?
+    if [ $watchdog_service_state == 0 ]; then
+            echo "Error: Unable to start watchdog service"
+    fi
+}
+
+disable_watchdog_service()
+{
+    systemctl disable watchdog
+    systemctl stop watchdog
+    systemctl status watchdog
+    if [ $watchdog_service_state == 1 ]; then
+            echo "Error: Unable to stop watchdog service"
+    fi
+}
+
+watchdog_init ()
+{
+    is_watchdog_dev_present
+    watchdog_dev_presence=$?
+    if [ $watchdog_dev_presence == 1 ]; then
+        is_watchdog_installed
+        installed_status=$?
+        if [ $installed_status == 1 ]; then
+            echo "Watchdog installed and ready"
+            is_watchdog_configured
+            config_status=$?
+            if [ $config_status == 0 ]; then
+                echo "Watchdog config being added"
+                add_watchdog_config
+                is_watchdog_configured
+                config_status=$?
+                if [ $config_status == 1 ]; then
+                    echo "Watchdog Config success"
+                else
+                    echo "Error: Watchdog Config Add Failed"
+                fi           
+            else
+                echo "Watchdog config being updated"
+                update_watchdog_config
+            fi
+
+        else
+            echo "Install watchdog"
+            install_watchdog
+            is_watchdog_installed
+            installed_status=$?
+            if [ $installed_status == 1 ]; then
+                echo "Watchdog installed and ready"
+                is_watchdog_configured
+                config_status=$?
+                if [ $config_status == 0 ]; then
+                    echo "Watchdog config being added"
+                    add_watchdog_config
+                    is_watchdog_configured
+                    config_status=$?
+                    if [ $config_status == 1 ]; then
+                        echo "Watchdog Config success"
+                    else
+                        echo "Error: Watchdog Config Add Failed"
+                    fi              
+                else
+                    echo "Watchdog config being updated"
+                    update_watchdog_config
+                fi
+            else
+                echo "Error: Watchdog installation failed."
+            fi
+
+        fi
+    else
+        is_watchdog_in_boot_config
+        boot_config_watchdog_presence=$?
+        #echo boot_config_watchdog_presence is $boot_config_watchdog_presence
+        if [ $boot_config_watchdog_presence == 0 ]; then
+            echo "Enable Watchdog in /boot/config.txt"
+            add_watchdog_to_boot_config
+            check_kernel_watchdog
+            boot_config_watchdog_presence=$?
+            if [ $boot_config_watchdog_presence == 1 ]; then
+                echo "Reboot in 5 seconds"
+                sleep 5
+                echo "Reboot"
+                reboot
+            else
+                echo "Error:Unable to update boot file"
+            fi
+        else
+            echo "Error: Boot file already contains changes. Try manual reboot"
+        fi
+    fi
+}
+
 do_exit()
 {
     log_docker_info end
@@ -163,7 +338,8 @@ update_dhcpcd_conf ()
     fi
 }
 
-
+#initialize watchdog
+watchdog_init
 
 ### Add aliases ################################
 alias_file=./.aliases_power
@@ -281,6 +457,9 @@ do_install ()
         do_uninstall
     fi
 
+    #disable watchdog
+    disable_watchdog_service
+
     # everthing is fine good to start the container
     #Check if local docker image is to be used.
     if [ $local_docker == 1 ]
@@ -329,6 +508,10 @@ do_install ()
         echo "5 second wait start"
         sleep 5
         echo "5 second wait complete"
+
+        #Enable watchdog
+        enable_watchdog_service
+
     else
         Error "!!! Error installing the [$service] "
     fi

--- a/test_watch_dog.sh
+++ b/test_watch_dog.sh
@@ -1,0 +1,150 @@
+#!/bin/bash
+
+# grep "dtparam=watchdog=on" /boot/config.txt
+# 
+# grep dtparam=watchdog=on /boot/config.txt -c
+# 
+# cmd="grep dtparam=watchdog=on /boot/config.txt -c"
+# watchdog_enabled=$($cmd)
+# 
+# 
+# FILE=/dev/watchdog
+# if test -f "$FILE"; then
+#     echo "$FILE exists."
+# else 
+#     echo "$FILE does not exist."
+# fi
+
+
+check_kernel_watchdog ()
+{
+    cmd="grep dtparam=watchdog=on /boot/config.txt -c"
+    watchdog_enabled=$($cmd)
+    if [ $watchdog_enabled == 0 ]; then
+        echo check_kernel_watchdog ret 0
+        return 0
+    fi
+    echo check_kernel_watchdog ret 1
+    return 1  
+}
+
+enable_kernel_watchdog ()
+{
+    echo 'dtparam=watchdog=on' >> /boot/config.txt
+}
+
+is_watchdog_dev_present ()
+{
+    CHAR_FILE=/dev/watchdog
+
+    if test -c $CHAR_FILE; then
+        return 1  
+    fi
+    return 0
+}
+
+is_watchdog_installed ()
+{
+    FILE=/etc/watchdog.conf
+    if test -f "$FILE"; then
+        return 1  
+    fi
+    return 0
+}
+
+install_watchdog ()
+{
+    apt-get update
+    apt-get install watchdog
+}
+
+is_watchdog_configured ()
+{
+    echo 'watchdog-device = /dev/watchdog' >> /etc/watchdog.conf
+    echo 'watchdog-timeout = 15' >> /etc/watchdog.conf
+    echo 'max-load-1 = 24' >> /etc/watchdog.conf    
+}
+
+configure_watchdog ()
+{
+    echo 'watchdog-device = /dev/watchdog' >> /etc/watchdog.conf
+    echo 'watchdog-timeout = 15' >> /etc/watchdog.conf
+    echo 'max-load-1 = 24' >> /etc/watchdog.conf    
+}
+
+enable_watchdog_service()
+{
+    systemctl enable watchdog
+    systemctl start watchdog
+    systemctl status watchdog
+}
+
+is_watchdog_service_enabled()
+{
+    cmd='systemctl is-active watchdog'
+    service_state=$($cmd)
+    if [ $service_state == "active" ]; then
+        return 1 ;
+    fi
+    return 0
+}
+
+watchdog_init ()
+{
+    #check_kernel_watchdog
+    #kernel_watchdog_presence=$?
+    #echo kernel_watchdog_presence is $kernel_watchdog_presence
+    #if [ $kernel_watchdog_presence == 0 ]; then
+    #    enable_kernel_watchdog
+    #    check_kernel_watchdog
+    #    kernel_watchdog_presence=$?
+    #    if [ $kernel_watchdog_presence == 1 ]; then
+    #        echo ready to reboot
+    #    else
+    #        echo unable to write to boot config
+    #    fi
+    #else
+        is_watchdog_dev_present
+        watchdog_dev_presence=$?
+        if [ $watchdog_dev_presence == 1 ]; then
+            is_watchdog_installed
+            installed_status=$?
+            echo installed_status is $installed_status
+            if [ $installed_status == 1 ]; then
+                echo watchdog installed and ready
+            else
+                echo Install watchdog
+                #install_watchdog
+                #configure_watchdog
+            fi
+        else
+            check_kernel_watchdog
+            kernel_watchdog_presence=$?
+            echo kernel_watchdog_presence is $kernel_watchdog_presence
+            if [ $kernel_watchdog_presence == 0 ]; then
+                enable_kernel_watchdog
+                check_kernel_watchdog
+                kernel_watchdog_presence=$?
+                if [ $kernel_watchdog_presence == 1 ]; then
+                    echo "Ready to reboot"
+                else
+                    echo "Error:Unable to update boot file"
+                fi
+            else
+                echo "Error: Boot file already contains changes. Try manual reboot"
+            fi
+        fi
+        is_watchdog_service_enabled
+        watchdog_service_state=$?
+        if [ $watchdog_service_state == "0" ]; then
+            enable_watchdog_service
+        fi
+        is_watchdog_service_enabled
+        watchdog_service_state=$?
+        if [ $watchdog_service_state == "0" ]; then
+                echo "Error: Unable to start service"
+        fi
+    #fi
+}
+
+watchdog_init

--- a/test_watch_dog.sh
+++ b/test_watch_dog.sh
@@ -90,67 +90,54 @@ is_watchdog_service_enabled()
 
 watchdog_init ()
 {
-    #check_kernel_watchdog
-    #kernel_watchdog_presence=$?
-    #echo kernel_watchdog_presence is $kernel_watchdog_presence
-    #if [ $kernel_watchdog_presence == 0 ]; then
-    #    enable_kernel_watchdog
-    #    check_kernel_watchdog
-    #    kernel_watchdog_presence=$?
-    #    if [ $kernel_watchdog_presence == 1 ]; then
-    #        echo ready to reboot
-    #    else
-    #        echo unable to write to boot config
-    #    fi
-    #else
-        is_watchdog_dev_present
-        watchdog_dev_presence=$?
-        if [ $watchdog_dev_presence == 1 ]; then
+    is_watchdog_dev_present
+    watchdog_dev_presence=$?
+    if [ $watchdog_dev_presence == 1 ]; then
+        is_watchdog_installed
+        installed_status=$?
+        if [ $installed_status == 1 ]; then
+            echo "Watchdog installed and ready"
+        else
+            echo "Install watchdog"
+            install_watchdog
+            configure_watchdog
             is_watchdog_installed
             installed_status=$?
             if [ $installed_status == 1 ]; then
                 echo "Watchdog installed and ready"
             else
-                echo "Install watchdog"
-                install_watchdog
-                configure_watchdog
-                is_watchdog_installed
-                installed_status=$?
-                if [ $installed_status == 1 ]; then
-                    echo "Watchdog installed and ready"
-                else
-                    echo "Error: Watchdog installation failed."
-                fi
-
+                echo "Error: Watchdog installation failed."
             fi
-        else
+
+        fi
+    else
+        check_kernel_watchdog
+        kernel_watchdog_presence=$?
+        echo kernel_watchdog_presence is $kernel_watchdog_presence
+        if [ $kernel_watchdog_presence == 0 ]; then
+            enable_kernel_watchdog
             check_kernel_watchdog
             kernel_watchdog_presence=$?
-            echo kernel_watchdog_presence is $kernel_watchdog_presence
-            if [ $kernel_watchdog_presence == 0 ]; then
-                enable_kernel_watchdog
-                check_kernel_watchdog
-                kernel_watchdog_presence=$?
-                if [ $kernel_watchdog_presence == 1 ]; then
-                    echo "Ready to reboot"
-                else
-                    echo "Error:Unable to update boot file"
-                fi
+            if [ $kernel_watchdog_presence == 1 ]; then
+                echo "Ready to reboot"
             else
-                echo "Error: Boot file already contains changes. Try manual reboot"
+                echo "Error:Unable to update boot file"
             fi
+        else
+            echo "Error: Boot file already contains changes. Try manual reboot"
         fi
-        is_watchdog_service_enabled
-        watchdog_service_state=$?
-        if [ $watchdog_service_state == "0" ]; then
-            enable_watchdog_service
-        fi
-        is_watchdog_service_enabled
-        watchdog_service_state=$?
-        if [ $watchdog_service_state == "0" ]; then
-                echo "Error: Unable to start service"
-        fi
-    #fi
+    fi
+    is_watchdog_service_enabled
+    watchdog_service_state=$?
+    if [ $watchdog_service_state == "0" ]; then
+        enable_watchdog_service
+    fi
+    is_watchdog_service_enabled
+    watchdog_service_state=$?
+    if [ $watchdog_service_state == "0" ]; then
+            echo "Error: Unable to start service"
+    fi
+
 }
 
 watchdog_init

--- a/test_watch_dog.sh
+++ b/test_watch_dog.sh
@@ -36,10 +36,8 @@ is_watchdog_in_boot_config ()
     cmd="grep dtparam=watchdog=on /boot/config.txt -c"
     watchdog_enabled=$($cmd)
     if [ $watchdog_enabled == 0 ]; then
-        #echo is_watchdog_in_boot_config ret 0
         return 0
     fi
-    #echo is_watchdog_in_boot_config ret 1
     return 1  
 }
 
@@ -102,6 +100,13 @@ enable_watchdog_service()
 {
     systemctl enable watchdog
     systemctl start watchdog
+    systemctl status watchdog
+}
+
+disable_watchdog_service()
+{
+    systemctl disable watchdog
+    systemctl stop watchdog
     systemctl status watchdog
 }
 
@@ -170,14 +175,15 @@ watchdog_init ()
 
         fi
     else
-        check_kernel_watchdog
-        kernel_watchdog_presence=$?
-        echo kernel_watchdog_presence is $kernel_watchdog_presence
-        if [ $kernel_watchdog_presence == 0 ]; then
-            enable_kernel_watchdog
+        is_watchdog_in_boot_config
+        boot_config_watchdog_presence=$?
+        #echo boot_config_watchdog_presence is $boot_config_watchdog_presence
+        if [ $boot_config_watchdog_presence == 0 ]; then
+            echo "Enable Watchdog in /boot/config.txt"
+            add_watchdog_to_boot_config
             check_kernel_watchdog
-            kernel_watchdog_presence=$?
-            if [ $kernel_watchdog_presence == 1 ]; then
+            boot_config_watchdog_presence=$?
+            if [ $boot_config_watchdog_presence == 1 ]; then
                 echo "Reboot in 5 seconds"
                 sleep 5
                 echo "Reboot"

--- a/test_watch_dog.sh
+++ b/test_watch_dog.sh
@@ -45,8 +45,7 @@ is_watchdog_dev_present ()
 
 is_watchdog_installed ()
 {
-    FILE=/etc/watchdog.conf
-    if test -f "$FILE"; then
+    if [ -x "$(command -v watchdog)" ]; then
         return 1  
     fi
     return 0
@@ -54,8 +53,8 @@ is_watchdog_installed ()
 
 install_watchdog ()
 {
-    apt-get update
-    apt-get install watchdog
+    #apt update
+    apt install watchdog
 }
 
 is_watchdog_configured ()
@@ -109,13 +108,20 @@ watchdog_init ()
         if [ $watchdog_dev_presence == 1 ]; then
             is_watchdog_installed
             installed_status=$?
-            echo installed_status is $installed_status
             if [ $installed_status == 1 ]; then
-                echo watchdog installed and ready
+                echo "Watchdog installed and ready"
             else
-                echo Install watchdog
-                #install_watchdog
-                #configure_watchdog
+                echo "Install watchdog"
+                install_watchdog
+                configure_watchdog
+                is_watchdog_installed
+                installed_status=$?
+                if [ $installed_status == 1 ]; then
+                    echo "Watchdog installed and ready"
+                else
+                    echo "Error: Watchdog installation failed."
+                fi
+
             fi
         else
             check_kernel_watchdog

--- a/watch_dog_init.sh
+++ b/watch_dog_init.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 
-
 is_watchdog_in_boot_config ()
 {
     cmd="grep dtparam=watchdog=on /boot/config.txt -c"
@@ -53,7 +52,7 @@ is_watchdog_configured ()
 update_watchdog_config ()
 {
     powerfly_log=$('pwd')/logging.txt
-    sed -i 's@file = [a-zA-Z0-9_-]*@file = '$powerfly_log'@g' /etc/watchdog.conf
+    sed -i 's@file = [a-zA-Z0-9_./-]*@file = '$powerfly_log'@' /etc/watchdog.conf
 }
 
 add_watchdog_config ()
@@ -78,23 +77,35 @@ is_watchdog_service_enabled()
 
 enable_watchdog_service()
 {
-    systemctl enable watchdog
-    systemctl start watchdog
-    systemctl status watchdog
     is_watchdog_service_enabled
     watchdog_service_state=$?
     if [ $watchdog_service_state == 0 ]; then
-            echo "Error: Unable to start watchdog service"
+        echo "Starting watchdog service"
+        systemctl enable watchdog
+        systemctl start watchdog
+        systemctl status --no-pager watchdog
+        is_watchdog_service_enabled
+        watchdog_service_state=$?
+        if [ $watchdog_service_state == 0 ]; then
+                echo "Error: Unable to start watchdog service"
+        fi
     fi
 }
 
 disable_watchdog_service()
 {
-    systemctl disable watchdog
-    systemctl stop watchdog
-    systemctl status watchdog
+    is_watchdog_service_enabled
+    watchdog_service_state=$?
     if [ $watchdog_service_state == 1 ]; then
-            echo "Error: Unable to stop watchdog service"
+        echo "Stopping watchdog service"
+        systemctl disable watchdog
+        systemctl stop watchdog
+        systemctl status --no-pager watchdog
+        is_watchdog_service_enabled
+        watchdog_service_state=$?
+        if [ $watchdog_service_state == 1 ]; then
+                echo "Error: Unable to stop watchdog service"
+        fi
     fi
 }
 

--- a/watch_dog_init.sh
+++ b/watch_dog_init.sh
@@ -1,35 +1,5 @@
 #!/bin/bash
 
-# grep "dtparam=watchdog=on" /boot/config.txt
-# 
-# grep dtparam=watchdog=on /boot/config.txt -c
-# 
-# cmd="grep dtparam=watchdog=on /boot/config.txt -c"
-# watchdog_enabled=$($cmd)
-# 
-# 
-# FILE=/dev/watchdog
-# if test -f "$FILE"; then
-#     echo "$FILE exists."
-# else 
-#     echo "$FILE does not exist."
-# fi
-
-#powerfly_log=$('pwd')/logging.txt
-#
-#echo '#Watchdog Config for PowerFly' >> pop.txt
-#echo 'watchdog-device = /dev/watchdog' >> pop.txt
-#echo 'watchdog-timeout = 60' >> pop.txt
-#echo 'max-load-1 = 24' >> pop.txt
-#echo ' file = 'sample_file  >> pop.txt
-#echo '#file = 'sample_file  >> pop.txt
-#echo ' file = 'sample_file  >> pop.txt
-#echo ' file = 'sample_file  >> pop.txt
-#echo 'change = 60'  >> pop.txt
-#
-#sed -i 's@ file = [a-zA-Z0-9_-]*@ file = '$powerfly_log'@g' pop.txt
-#
-#exit 0
 
 is_watchdog_in_boot_config ()
 {

--- a/watch_dog_init.sh
+++ b/watch_dog_init.sh
@@ -96,20 +96,6 @@ add_watchdog_config ()
     echo 'change = 60'  >> /etc/watchdog.conf
 }
 
-enable_watchdog_service()
-{
-    systemctl enable watchdog
-    systemctl start watchdog
-    systemctl status watchdog
-}
-
-disable_watchdog_service()
-{
-    systemctl disable watchdog
-    systemctl stop watchdog
-    systemctl status watchdog
-}
-
 is_watchdog_service_enabled()
 {
     cmd='systemctl is-active watchdog'
@@ -118,6 +104,28 @@ is_watchdog_service_enabled()
         return 1 ;
     fi
     return 0
+}
+
+enable_watchdog_service()
+{
+    systemctl enable watchdog
+    systemctl start watchdog
+    systemctl status watchdog
+    is_watchdog_service_enabled
+    watchdog_service_state=$?
+    if [ $watchdog_service_state == 0 ]; then
+            echo "Error: Unable to start watchdog service"
+    fi
+}
+
+disable_watchdog_service()
+{
+    systemctl disable watchdog
+    systemctl stop watchdog
+    systemctl status watchdog
+    if [ $watchdog_service_state == 1 ]; then
+            echo "Error: Unable to stop watchdog service"
+    fi
 }
 
 watchdog_init ()
@@ -195,17 +203,6 @@ watchdog_init ()
             echo "Error: Boot file already contains changes. Try manual reboot"
         fi
     fi
-    is_watchdog_service_enabled
-    watchdog_service_state=$?
-    if [ $watchdog_service_state == "0" ]; then
-        enable_watchdog_service
-    fi
-    is_watchdog_service_enabled
-    watchdog_service_state=$?
-    if [ $watchdog_service_state == "0" ]; then
-            echo "Error: Unable to start service"
-    fi
-
 }
 
-watchdog_init
+#watchdog_init


### PR DESCRIPTION
For 60 seconds, if logging.txt is not updated, watchdog would cause system restart.
Watchdog service is stopped before installation of powerfly service, and started after starting powerfly service.
Setting:
watchdog-timeout = 60
max-load-1 = 24
file = /home/pi/powerfly-arun-x2/logging.txt
change = 60

